### PR TITLE
Fix plugin installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 ruby '>=2.5.0', :engine => 'jruby', :engine_version => '>=9.2.0.0'
-
+source 'https://rubygems.org'
 # Get other dependencies from logstash-filter-csharp.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,11 @@ PATH
   remote: .
   specs:
     logstash-filter-csharp (0.2.1)
-      json (>= 2.3.0, < 3.0.0)
+      json (>= 1.8.0, < 2.0.0)
       logstash-core-plugin-api (>= 1.60, < 3.0)
 
 GEM
+  remote: https://rubygems.org/
   specs:
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
@@ -33,7 +34,7 @@ GEM
     jar-dependencies (0.4.1)
     jrjackson (0.4.12-java)
     jruby-openssl (0.9.19-java)
-    json (2.3.1-java)
+    json (1.8.6-java)
     kramdown (1.14.0)
     logstash-core (5.6.4-java)
       chronic_duration (= 0.10.6)
@@ -124,6 +125,7 @@ GEM
 
 PLATFORMS
   java
+  universal-java-15
 
 DEPENDENCIES
   logstash-devutils (>= 1.3.6, < 3.0.0)
@@ -133,4 +135,4 @@ RUBY VERSION
    ruby 2.5.7p0 (jruby 9.2.13.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.2

--- a/logstash-filter-csharp.gemspec
+++ b/logstash-filter-csharp.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.licenses = ['Apache-2.0']
   s.summary = 'This filter parses C# stack traces and exception messages.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-csharp. This gem is not a stand-alone program.'
-  s.authors = ['Julian Rüth', 'Solomiia Demkiv']
+  s.authors = ['Julian Rüth', 'Solomiia Demkiv', 'Leonard Kleinhans']
   s.email = 'infrastructure@miaplaza.com'
   s.homepage = 'https://github.com/Miaplaza/logstash-filter-csharp'
   s.require_paths = ['lib']

--- a/logstash-filter-csharp.gemspec
+++ b/logstash-filter-csharp.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '< 3.0'
-  s.add_runtime_dependency 'json', '>=2.3.0', '< 3.0.0'
+  s.add_runtime_dependency 'json', '>=1.8.0', '< 2.0.0'
   s.add_development_dependency 'logstash-devutils', '>= 1.3.6', '< 3.0.0'
 end


### PR DESCRIPTION
Apparently that upgrade was about fixing a security vulnerability, most
likely
https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/.

JRuby was howeever not affected by this (see
https://twitter.com/i/web/status/1253824129460928514).

However the (logstash) built-in input plugin logstash-input-s3 depends
on logstash-mixin-aws which depends on aws-sdk-v1 which depends on
json ~>1.4 so trying to install with a json > 2 dependency fails in
logstash